### PR TITLE
Fixes Issue #24. Added bottom margin to #main.

### DIFF
--- a/src/scss/panel.scss
+++ b/src/scss/panel.scss
@@ -43,6 +43,7 @@ html, body {
     padding-left: 1.6em;
     padding-right: 1.6em;
   }
+  margin-bottom: 61px;
 }
 
 


### PR DESCRIPTION
# main div needed a bottom margin due to the #menu div being fixed position. It needed a minimum of 46px (the height of the #menu div), but I gave it an extra 15px to give extra space at the bottom.
