### PR TITLE
SCDT : handleRenderError catch

### DIFF
--- a/src/js/inject/sidecar.debug.js
+++ b/src/js/inject/sidecar.debug.js
@@ -577,10 +577,26 @@
         });
 
         Debug.prototype.AppStream = new ActivityStream();
+
+        /**
+         * Override error.handleRenderError method to provide more information on render error.
+         */
+        var _handleRenderError = Sidecar.error.handleRenderError;
+
+        Debug.prototype._handleRenderError = function(component, method, additionalInfo) {
+            console.log('=== handleRenderError Information ===');
+            console.log('Name: ' + additionalInfo.name);
+            console.log('Type: ' + additionalInfo.type);
+            console.log('== ComponentInfo ==', component);
+            console.log('== AdditionalInfo ==', additionalInfo);
+            return _handleRenderError.apply(_handleRenderError, arguments);
+        };
+
         return Debug;
 
     })();
 
     Sidecar.debug = new Sidecar.Debug();
+    Sidecar.error.handleRenderError = Sidecar.error.handleRenderError ? Sidecar.debug._handleRenderError : undefined;
 
 }).call(this);


### PR DESCRIPTION
Catch and extend handleRenderError to grab more information when render failed.

Based on the following use case:
Problem:
Exception occurs during render and anything that Sidecar says by default error like "Failed to render a view". To examine the problem we need to go to `error.js` file, put breakpoint within and investigate the stack trace. 
Nice to have:
Will be great if `SidecarDevTools` extension catch this exceptions and provide more information about the render fail.
