### PR TITLE
Top modules bar not loading in Forecasts after SugarDebug is started.

### DIFF
--- a/src/js/inject/sidecar.debug.js
+++ b/src/js/inject/sidecar.debug.js
@@ -269,6 +269,12 @@
 
         Debug.prototype._onHookLayoutRender = function() {
             this.$el.attr('data-debug-cid', this.cid);
+
+            if (!_components[this.cid]) {
+                // ignore components that we aren't mapping
+                return;
+            }
+
             _components[this.cid].renderCount = _components[this.cid].renderCount ? ++_components[this.cid].renderCount : 1;
             var performance = Array.prototype.slice.call(arguments, -1).pop();
             var lastRenderTime = _components[this.cid].performance;


### PR DESCRIPTION
When the user is in the Forecasts module and starts the Sidecar Debug Mode, the page is reloaded but the top modules bar doesn't load.

http://screencast.com/t/bxMZqXZa

One of our partners has reported this issue.
