### PR TITLE
Increase minimum version of chrome required

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,7 @@
         "js/inject/sidecar.debug.js"
     ],
 
-    "minimum_chrome_version": "20.0.1132.57",
+    "minimum_chrome_version": "50",
 
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 


### PR DESCRIPTION
Chrome is always updating automatically and to use ES6 we need a more
recent version.

Also, most of the developers are using recent versions of Chrome anyway.
